### PR TITLE
adds a toggle event to the options + adds a isActive() method, returns this._choice

### DIFF
--- a/src/leaflet-ruler.js
+++ b/src/leaflet-ruler.js
@@ -13,6 +13,9 @@
   L.Control.Ruler = L.Control.extend({
     options: {
       position: 'topright',
+      events: {
+        onToggle: function (is_active) { }
+      },
       circleMarker: {
         color: 'red',
         radius: 2
@@ -32,6 +35,9 @@
         factor: null
       }
     },
+    isActive: function () {
+      return this._choice;
+    },
     onAdd: function(map) {
       this._map = map;
       this._container = L.DomUtil.create('div', 'leaflet-bar');
@@ -48,6 +54,7 @@
     },
     _toggleMeasure: function() {
       this._choice = !this._choice;
+      this.options.events.onToggle(this._choice);
       this._clickedLatLong = null;
       this._clickedPoints = [];
       this._totalLength = 0;


### PR DESCRIPTION
A solution to this issue: https://github.com/gokertanrisever/leaflet-ruler/issues/3
I used this so my custom code can use this "event", which is actually a callback function, and the isActive() method, in such a way that all interactive layers can be put on interactive: false . This way, the default behavior of your plugin (which is logical) will not change. But coders can use this functionality to enable/disable whatever they want when toggling the ruler.