### PR TITLE
Migrate rawgit to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A simple leaflet plugin to measure **true bearing** and **distance** between cli
 - Create a [leaflet map](http://leafletjs.com/examples/quick-start/)
 - Include leaflet-ruler.js and leaflet-ruler.css files.
 ```html
-<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/gokertanrisever/leaflet-ruler/master/src/leaflet-ruler.css">
-<script src="https://cdn.rawgit.com/gokertanrisever/leaflet-ruler/master/src/leaflet-ruler.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/gokertanrisever/leaflet-ruler@master/src/leaflet-ruler.css" integrity="sha384-P9DABSdtEY/XDbEInD3q+PlL+BjqPCXGcF8EkhtKSfSTr/dS5PBKa9+/PMkW2xsY" crossorigin="anonymous">  
+<script src="https://cdn.jsdelivr.net/gh/gokertanrisever/leaflet-ruler@master/src/leaflet-ruler.js" integrity="sha384-N2S8y7hRzXUPiepaSiUvBH1ZZ7Tc/ZfchhbPdvOE5v3aBBCIepq9l+dBJPFdo1ZJ" crossorigin="anonymous"></script>
 ```
 - Add Ruler control to map
 ```js


### PR DESCRIPTION
Rawgit is no longer maintained: https://rawgit.com.
In my app, I have migrated to jsdelivr using https://www.jsdelivr.com/rawgit, and added integrity hash for security with https://www.srihash.org.

Suggested changes in your README for new users.