### PR TITLE
Added package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/package-lock.json
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "leaflet-ruler",
+  "version": "1.0.0",
+  "description": "A simple leaflet plugin to measure true bearing and distance between clicked points.",
+  "main": "src/leaflet-ruler.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gokertanrisever/leaflet-ruler.git"
+  },
+  "keywords": [
+    "leaflet",
+    "measure"
+  ],
+  "author": "Göker Tanrısever (https://www.linkedin.com/in/gokertanrisever/)",
+  "contributors": [],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gokertanrisever/leaflet-ruler/issues"
+  },
+  "homepage": "https://github.com/gokertanrisever/leaflet-ruler#readme",
+  "devDependencies": {},
+  "peerDependencies": {
+    "leaflet": "^1.0.0"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
The projects needs a `package.json` manifest file in order to install it directly in other projects using `npm`.

This PR provides a starting point for a working manifest file. After applying the PR it is possible to run:

    npm install --save https://github.com/gokertanrisever/leaflet-ruler/tarball/master

to install `leaflet-ruler` as a dependency.