### PR TITLE
feat: Add maxPoints option to Leaflet Ruler control

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ L.control.ruler(options).addTo(map);
 ```js
 options: {
       position: 'topright',         // Leaflet control position option
+      maxPoints: null               // Maximum number of points in one line
       circleMarker: {               // Leaflet circle marker options for points used in this plugin
         color: 'red',
         radius: 2

--- a/src/leaflet-ruler.js
+++ b/src/leaflet-ruler.js
@@ -13,6 +13,7 @@
   L.Control.Ruler = L.Control.extend({
     options: {
       position: 'topright',
+      maxPoints: null,
       events: {
         onToggle: function (is_active) { }
       },
@@ -106,6 +107,13 @@
         L.circleMarker(this._clickedLatLong, this.options.circleMarker).bindTooltip(text, {permanent: true, className: 'result-tooltip'}).addTo(this._pointLayer).openTooltip();
       }
       this._clickCount++;
+
+      if (
+        this.options.maxPoints !== null &&
+        this._clickCount >= this.options.maxPoints
+      ) {
+        this._closePath();
+      }
     },
     _moving: function(e) {
       if (this._clickedLatLong){


### PR DESCRIPTION
This commit adds a new option, maxPoints, to the Leaflet Ruler control. The maxPoints option allows users to set a maximum number of points in one line when measuring distances on the map. When the maximum number of points is reached, the line is automatically closed.

The maxPoints option is added to both the README.md file and the leaflet-ruler.js file.